### PR TITLE
Add Timestamp to UDP messages.

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -76,25 +76,23 @@ fn main() {
 
         let mut cids_to_disconnect = vec![];
 
-        let msgs = server
-            .recv::<Msg>()
-            .unwrap()
-            .map(|(cid, msg)| (cid, msg));
-        for (cid, msg) in msgs {
+
+        for msg in server.recv::<Msg>().unwrap() {
             println!(
                 "Client {} sent message: {}: \"{}\"",
-                cid, msg.from, msg.text
+                msg.cid, msg.from, msg.text
             );
 
             // If the client sent the message of "disconnect-me", disconnect them.
             if msg.text == "disconnect-me" {
-                cids_to_disconnect.push(cid);
+                cids_to_disconnect.push(msg.cid);
                 continue;
             }
 
             // Broadcast the message to all other clients.
-            server.send_spec(msg, CIdSpec::Except(cid)).unwrap();
+            server.send_spec(msg.m, CIdSpec::Except(msg.cid)).unwrap();
         }
+
         for cid in cids_to_disconnect {
             server
                 .disconnect(

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -41,10 +41,7 @@ fn main() {
     let parts = table.build::<Connection, Response, Disconnect>().unwrap();
 
     // Start the server.
-    let server = Server::new(addr, parts);
-
-    // Block until the server is finished being created.
-    let mut server = server.expect("Failed to create server.");
+    let mut server = Server::new(addr, parts).expect("Failed to create server.");
 
     let blacklisted_users = vec!["John", "Jane"];
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,10 @@ mod client;
 mod header;
 mod message_table;
 mod server;
+mod time;
 
 pub use client::{Client, PendingClient, OptionPendingClient};
-pub use header::Header;
+pub use header::TcpHeader;
 pub use message_table::{MsgRegError, MsgTable, MsgTableParts, SortedMsgTable};
 pub use net::{CId, MId, Transport};
 pub use server::Server;

--- a/src/net.rs
+++ b/src/net.rs
@@ -157,6 +157,7 @@ impl CIdSpec {
 }
 
 /// An untyped network message containing the message content, along with the metadata associated.
+#[derive(Debug)]
 pub(crate) struct ErasedNetMsg {
     /// The [`CId`] that the message was sent from.
     pub(crate) cid: CId,
@@ -181,6 +182,7 @@ impl ErasedNetMsg {
 }
 
 /// A network message containing the message content, along with the metadata associated.
+#[derive(Eq, PartialEq, Copy, Clone, Debug)]
 pub struct NetMsg<'n, T: Any + Send + Sync> {
     /// The [`CId`] that the message was sent from.
     pub cid: CId,

--- a/src/net.rs
+++ b/src/net.rs
@@ -5,6 +5,7 @@ use std::any::Any;
 use std::fmt::{Debug, Display, Formatter};
 use std::io;
 use std::io::Error;
+use std::ops::Deref;
 
 /// The maximum safe message size that can be sent on udp,
 /// after taking off the possible overheads from the transport.
@@ -152,5 +153,52 @@ impl CIdSpec {
             (Only(only), Except(except)) => only != except,
             (Except(except), Only(only)) => only != except,
         }
+    }
+}
+
+/// An untyped network message containing the message content, along with the metadata associated.
+pub(crate) struct ErasedNetMsg {
+    /// The [`CId`] that the message was sent from.
+    pub(crate) cid: CId,
+    /// The timestamp that the message was sent in unix millis.
+    ///
+    /// This is only `Some` if the message was sent with UDP.
+    pub(crate) time: Option<u32>,
+    /// The actual message.
+    pub(crate) msg: Box<dyn Any + Send + Sync>,
+}
+
+impl ErasedNetMsg {
+    /// Converts this to NetMsg, borrowed from this.
+    pub(crate) fn to_typed<T: Any + Send + Sync>(&self) -> Option<NetMsg<T>> {
+        let msg = self.msg.downcast_ref()?;
+        Some(NetMsg {
+            cid: self.cid,
+            time: self.time,
+            m: msg,
+        })
+    }
+}
+
+/// A network message containing the message content, along with the metadata associated.
+pub struct NetMsg<'n, T: Any + Send + Sync> {
+    /// The [`CId`] that the message was sent from.
+    pub cid: CId,
+    /// The timestamp that the message was sent in unix millis.
+    ///
+    /// This is always `Some` if the message was sent with UDP,
+    /// and always `None` if sent with TCP.
+    pub time: Option<u32>,
+    /// The actual message.
+    ///
+    /// Borrowed from the client or server.
+    pub m: &'n T,
+}
+
+impl<'n, T: Any + Send + Sync> Deref for NetMsg<'n, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.m
     }
 }

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,6 +1,6 @@
 //! Networking things that are not specific to either transport.
 
-pub use crate::header::Header;
+pub use crate::header::TcpHeader;
 use std::any::Any;
 use std::fmt::{Debug, Display, Formatter};
 use std::io;

--- a/src/server.rs
+++ b/src/server.rs
@@ -378,7 +378,6 @@ impl Server {
             self.msg_buff[mid]
                 .iter()
                 .map(|m| m.to_typed::<T>().unwrap())
-                .map(|_| todo!())
         )
     }
 

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,61 @@
+//! An attempt to serialize the current time as a u16.
+//!
+//! To do this, we send the least significant 16 bits of the unix millis.
+//! Then on the receiving side, we can assume that the next 16 bits of the
+//! send time are going to be the same, or 1 less.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Gets the current unix millis as a u32.
+pub(crate) fn unix_millis() -> u32 {
+    let millis = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("Current system time is earlier than the UNIX_EPOCH")
+        .as_millis();
+    (millis & 0xFFFF_FFFF) as u32
+}
+
+/// Gets the current unix millis as a u16.
+pub(crate) fn get_millis() -> u16 {
+    (unix_millis() & 0xFFFF) as u16
+}
+
+/// Uses the 16 least significant bits of the unix millis time stamp, and reconstructs
+/// rest.
+pub(crate) fn reconstruct_millis(lsb: u16) -> u32 {
+    reconstruct_millis_inner(unix_millis(), lsb)
+}
+
+/// The logic for reconstructing the millis.
+///
+/// Separated to allow testing.
+#[inline]
+fn reconstruct_millis_inner(now: u32, lsb: u16) -> u32 {
+    let now_lsb = (now & 0xFFFF) as u16;
+    let mut msb = now & 0xFFFF_0000;
+    if lsb > now_lsb { msb -= 0x0001_0000; }
+    msb | lsb as u32
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::time::{get_millis, reconstruct_millis_inner};
+
+    #[test]
+    fn test_reconstruction() {
+        let points: Vec<(u32, u32)> = vec![
+            // Send stamp, Recv stamp
+            (0x89F9_8103, 0x89F9_8103),
+            (0x3F11_7904, 0x3F11_9035),
+            (0x23AC_9723, 0x23AD_1039),
+            (0x1839_8183, 0x183A_4039),
+        ];
+
+        for point in points {
+            // Test reconstruction
+            let lsb = (point.0 & 0xFFFF) as u16;
+            let reconstructed = reconstruct_millis_inner(point.1, lsb);
+            assert_eq!(reconstructed, point.0, "Send:\t\t\t {:#10x},\nReceive:\t\t {:#10x},\nReconstructed:\t {:#10x}", point.0, point.1, reconstructed);
+        }
+    }
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -15,11 +15,6 @@ pub(crate) fn unix_millis() -> u32 {
     (millis & 0xFFFF_FFFF) as u32
 }
 
-/// Gets the current unix millis as a u16.
-pub(crate) fn get_millis() -> u16 {
-    (unix_millis() & 0xFFFF) as u16
-}
-
 /// Uses the 16 least significant bits of the unix millis time stamp, and reconstructs
 /// rest.
 pub(crate) fn reconstruct_millis(lsb: u16) -> u32 {
@@ -39,7 +34,7 @@ fn reconstruct_millis_inner(now: u32, lsb: u16) -> u32 {
 
 #[cfg(test)]
 mod tests {
-    use crate::time::{get_millis, reconstruct_millis_inner};
+    use crate::time::reconstruct_millis_inner;
 
     #[test]
     fn test_reconstruction() {

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -4,7 +4,7 @@ use log::{error, trace, warn};
 use std::io;
 use std::io::{Error, ErrorKind};
 use std::net::{SocketAddr, UdpSocket};
-use crate::header::TCP_HEADER_LEN;
+use crate::header::UDP_HEADER_LEN;
 
 /// A type wrapping a [`UdpSocket`].
 ///
@@ -73,7 +73,7 @@ impl UdpCon {
     /// The shared code for sending a message.
     /// Produces a buffer given the payload
     fn send_shared(&self, mid: MId, payload: &[u8]) -> io::Result<Vec<u8>> {
-        let total_len = payload.len() + TCP_HEADER_LEN;
+        let total_len = payload.len() + UDP_HEADER_LEN;
         let mut buff = vec![0; total_len];
         // Check if the message is valid, and should be sent.
         if total_len > MAX_MESSAGE_SIZE {
@@ -102,7 +102,7 @@ impl UdpCon {
             buff[i] = b;
         }
         for (i, b) in payload.iter().enumerate() {
-            buff[i+TCP_HEADER_LEN] = *b;
+            buff[i+UDP_HEADER_LEN] = *b;
         }
         Ok(buff)
     }
@@ -134,8 +134,8 @@ impl UdpCon {
             return Err(Error::new(ErrorKind::NotConnected, e_msg));
         }
 
-        let header = TcpHeader::from_be_bytes(&self.buff[..TCP_HEADER_LEN]);
-        let total_expected_len = header.len + TCP_HEADER_LEN;
+        let header = TcpHeader::from_be_bytes(&self.buff[..UDP_HEADER_LEN]);
+        let total_expected_len = header.len + UDP_HEADER_LEN;
 
         if total_expected_len > MAX_MESSAGE_SIZE {
             let e_msg = format!(
@@ -160,7 +160,7 @@ impl UdpCon {
             return Err(Error::new(ErrorKind::InvalidData, e_msg));
         }
 
-        Ok((header.mid, &self.buff[TCP_HEADER_LEN..header.len + TCP_HEADER_LEN]))
+        Ok((header.mid, &self.buff[UDP_HEADER_LEN..header.len + UDP_HEADER_LEN]))
     }
 
     /// Moves the internal [`TcpStream`] into or out of nonblocking mode.

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,5 +1,5 @@
 use crate::net::{MAX_MESSAGE_SIZE, MAX_SAFE_MESSAGE_SIZE};
-use crate::{TcpHeader, MId};
+use crate::MId;
 use log::{error, trace, warn};
 use std::io;
 use std::io::{Error, ErrorKind};
@@ -95,7 +95,7 @@ impl UdpCon {
         }
         // Message can be sent!
 
-        let header = TcpHeader::new(mid, payload.len());
+        let header = UdpHeader::new(mid);
         let h_bytes = header.to_be_bytes();
         // put the header in the front of the message
         for (i, b) in h_bytes.into_iter().enumerate() {
@@ -139,17 +139,17 @@ impl UdpCon {
         Ok((header.mid, header.time, &self.buff[UDP_HEADER_LEN..n]))
     }
 
-    /// Moves the internal [`TcpStream`] into or out of nonblocking mode.
+    /// Moves the internal [`UdpSocket`] into or out of nonblocking mode.
     pub fn set_nonblocking(&self, nonblocking: bool) -> io::Result<()> {
         self.udp.set_nonblocking(nonblocking)
     }
 
-    /// Returns the socket address of the remote peer of this TCP connection.
+    /// Returns the socket address of the remote peer of this UDP connection.
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.udp.peer_addr()
     }
 
-    /// Returns the socket address of the local half of this TCP connection.
+    /// Returns the socket address of the local half of this UDP connection.
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.udp.local_addr()
     }

--- a/tests/send_recv.rs
+++ b/tests/send_recv.rs
@@ -38,14 +38,14 @@ fn send_recv() {
     let tcp_msgs: Vec<_> = server.recv::<TcpMsg>().unwrap().collect();
     assert_eq!(tcp_msgs.len(), 10); // Make sure all 10 tcp messages went through.
 
-    for (i, p) in tcp_msgs.into_iter().enumerate() {
+    for (i, msg) in tcp_msgs.into_iter().enumerate() {
         // TCP is reliable ordered. Assert that all messages arrive in the correct order.
-        assert_eq!(p.1.msg, format!("Test TCP Msg {}", i));
+        assert_eq!(msg.msg, format!("Test TCP Msg {}", i));
     }
 
     // Despite UDP being unreliable, we are sending the messages through localhost
     // so none should get lost.
-    let udp_msgs: Vec<_> = server.recv::<UdpMsg>().unwrap().map(|m| m.1).collect();
+    let udp_msgs: Vec<_> = server.recv::<UdpMsg>().unwrap().map(|m| m.m).collect();
     assert_eq!(udp_msgs.len(), 10); // Make sure all 10 udp messages went through.
 
     // Udp is unreliable unordered. Assert that all messages arrive.
@@ -86,7 +86,7 @@ fn send_recv() {
 
     // Despite UDP being unreliable, we are sending the messages through localhost
     // so none should get lost.
-    let udp_msgs: Vec<_> = client.recv::<UdpMsg>().unwrap().collect();
+    let udp_msgs: Vec<_> = client.recv::<UdpMsg>().unwrap().map(|msg| msg.m).collect();
     assert_eq!(udp_msgs.len(), 10); // Make sure all 10 udp messages went through.
 
     // Udp is unreliable unordered. Assert that all messages arrive.

--- a/tests/send_recv.rs
+++ b/tests/send_recv.rs
@@ -40,7 +40,7 @@ fn send_recv() {
 
     for (i, p) in tcp_msgs.into_iter().enumerate() {
         // TCP is reliable ordered. Assert that all messages arrive in the correct order.
-        assert_eq!(p.1.msg, format!("Test TCP message {}", i));
+        assert_eq!(p.1.msg, format!("Test TCP Msg {}", i));
     }
 
     // Despite UDP being unreliable, we are sending the messages through localhost
@@ -50,7 +50,7 @@ fn send_recv() {
 
     // Udp is unreliable unordered. Assert that all messages arrive.
     for i in 0..10 {
-        let msg = format!("Test UDP message {}", i);
+        let msg = format!("Test UDP Msg {}", i);
         assert!(udp_msgs.contains(&&UdpMsg::new(msg)));
     }
 

--- a/todo.md
+++ b/todo.md
@@ -3,9 +3,9 @@
 - [ ] Config options (instead of constants)
 - [x] Add Cargo.toml dependency copy-pasta in docs.rs and GitHub.
 - [x] Make send calls take an immutable reference by using a ReadWriteLock.
-- [ ] `bevy-pigeon`, and `carrier-pigeon` might have enough documentation warrant a book.
 - [x] Remove the Register custom, as custom `Serialize`/`Deserialize` impls are allowed.
 - [x] Remove the `<C, R, D>` generics as they end up everywhere.
+- [ ] Standardize logging.
 
 ## For v0.4.0:
 - [ ] Query support.

--- a/todo.md
+++ b/todo.md
@@ -6,6 +6,7 @@
 - [x] Remove the Register custom, as custom `Serialize`/`Deserialize` impls are allowed.
 - [x] Remove the `<C, R, D>` generics as they end up everywhere.
 - [ ] Standardize logging.
+- [ ] Make sure that you can't receive a tcp message on udp and vice versa.
 
 ## For v0.4.0:
 - [ ] Query support.


### PR DESCRIPTION
This adds a timestamp to UDP messages, this way there is some way to order them. also adds a `NetMsg<M>` struct that wraps networking messages with their meta data (plain tuples were used before). 
The timestamping is done by sending the least significant 16 bits of the Unix millis. On the server, it uses the fact that messages aren't going to arrive more than 65 seconds later to reconstruct the rest of the unix millis. This uses the system clock, so if the system clock is not correct you may encounter issues. The timestamps are just added as meta in the NetMsg struct, and are not used directly by `carrier-pigeon`. If you cant verify the correctness of the system clock, or just dont want this feature, you can just no use the `time` field of the NetMsg.