### PR TITLE
Feature/generic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ bevy = { version = "0.9", optional = true }
 dashmap = "5.4"
 crossbeam-channel = "0.5"
 serde = { version = "1.0", features = ["derive"] }
+downcast-rs = "1.2"
 bincode = "1.3"
 hashbrown = "0.13"
 log = "0.4"

--- a/quickstart.md
+++ b/quickstart.md
@@ -4,7 +4,7 @@ This will walk you through what you need to know to use `carrier-pigeon`.
 
 ### Messages
 
-Messages are simple rust types that implement the `Any + Send + Sync` traits, and serde's `Serialize` and 
+Messages are simple rust types that implement the `NetMsg` traits, and serde's `Serialize` and 
 `DeserializeOwned` traits. This means making new message types is simple and almost boilerplate free. Each message type
 is independent of the others. This means adding another message type won't mess with any of the other messages/logic.
 This not only makes it scalable for your code, but makes it easy for plugins to add their own message types without

--- a/src/connection/ack_system.rs
+++ b/src/connection/ack_system.rs
@@ -29,7 +29,7 @@ pub(crate) struct AckBitfields {
 /// other than the header. Since this differs between client and server (server needs to keep track
 /// of a to address), it is made a generic parameter.
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
-pub(crate) struct AckSystem<SD: Debug + Clone> {
+pub(crate) struct AckSystem<SD: Clone> {
     /// The current [`AckNum`] for outgoing messages.
     outgoing_counter: AckNum,
     /// The current ack_offset value for the front end of the buffer.
@@ -47,7 +47,7 @@ pub(crate) struct AckSystem<SD: Debug + Clone> {
     saved_msgs: HashMap<AckNum, (Instant, MsgHeader, SD)>,
 }
 
-impl<SD: Debug + Clone> AckSystem<SD> {
+impl<SD: Clone> AckSystem<SD> {
     /// Creates a new [`AckSystem`].
     pub fn new() -> Self {
         let mut deque = VecDeque::new();

--- a/src/connection/client_connection.rs
+++ b/src/connection/client_connection.rs
@@ -14,12 +14,12 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 
 /// [`ReliableSystem`] with the generic parameters set for a server.
-type ClientReliableSystem = ReliableSystem<Arc<Vec<u8>>, Box<dyn NetMsg>>;
+type ClientReliableSystem<C: NetMsg, A: NetMsg, R: NetMsg, D: NetMsg> = ReliableSystem<Arc<Vec<u8>>, Box<dyn NetMsg>, C, A, R, D>;
 
 /// A wrapper around the the [`ClientTransport`] that adds the reliability and ordering.
-pub(crate) struct ClientConnection<T: ClientTransport> {
+pub(crate) struct ClientConnection<T: ClientTransport, C: NetMsg, A: NetMsg, R: NetMsg, D: NetMsg> {
     /// The [`MsgTable`] to use for sending and receiving messages.
-    msg_table: MsgTable,
+    msg_table: MsgTable<C, A, R, D>,
     /// The error that caused the client to disconnect.
     disconnect_err: Option<Error>,
     /// The [`Transport`] to use to send and receive the messages, if the connection is open.
@@ -27,13 +27,13 @@ pub(crate) struct ClientConnection<T: ClientTransport> {
     /// The system used to generate ping messages and estimate the RTT.
     ping_sys: ClientPingSystem,
     /// The [`ReliableSystem`] to add optional reliability to messages.
-    reliable_sys: ClientReliableSystem,
+    reliable_sys: ClientReliableSystem<C, A, R, D>,
     /// A buffer for messages that are ready to be received.
     ready: VecDeque<(MsgHeader, Box<dyn NetMsg>)>,
 }
 
-impl<T: ClientTransport> ClientConnection<T> {
-    pub fn new(msg_table: MsgTable) -> Self {
+impl<T: ClientTransport, C: NetMsg, A: NetMsg, R: NetMsg, D: NetMsg> ClientConnection<T, C, A, R, D> {
+    pub fn new(msg_table: MsgTable<C, A, R, D>) -> Self {
         Self {
             msg_table: msg_table.clone(),
             disconnect_err: None,

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -9,9 +9,9 @@ mod test_connection;
 
 use crate::util::DoubleHashMap;
 use crate::CId;
-use std::any::Any;
 use std::collections::VecDeque;
 use std::net::SocketAddr;
+use crate::messages::NetMsg;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug, Hash)]
 pub enum ConnectionListError {
@@ -25,7 +25,6 @@ pub enum ConnectionListError {
 ///
 /// Also manages a `addrs` which holds a sorted list of all the addresses that are
 /// connected.
-#[derive(Debug)]
 struct ConnectionList {
     /// The current [`CId`]. The id to assign to new connections (then increment).
     current_cid: CId,
@@ -33,7 +32,7 @@ struct ConnectionList {
     cid_addr: DoubleHashMap<CId, SocketAddr>,
     /// A que that keeps track of new unhandled connections.
     // TODO: I dont think a cid needs to be assigned until/unless the connection is accepted.
-    pending_connections: VecDeque<(CId, SocketAddr, Box<dyn Any + Send + Sync>)>,
+    pending_connections: VecDeque<(CId, SocketAddr, Box<dyn NetMsg>)>,
 }
 
 impl ConnectionList {
@@ -57,7 +56,7 @@ impl ConnectionList {
     pub fn new_pending(
         &mut self,
         addr: SocketAddr,
-        connection_msg: Box<dyn Any + Send + Sync>,
+        connection_msg: Box<dyn NetMsg>,
     ) -> Result<CId, ConnectionListError> {
         let cid = self.current_cid;
         self.current_cid += 1;
@@ -67,7 +66,7 @@ impl ConnectionList {
     }
 
     /// Gets the next pending connection if there is one.
-    pub fn get_pending(&mut self) -> Option<(CId, SocketAddr, Box<dyn Any + Send + Sync>)> {
+    pub fn get_pending(&mut self) -> Option<(CId, SocketAddr, Box<dyn NetMsg>)> {
         self.pending_connections.pop_front()
     }
 

--- a/src/connection/reliable.rs
+++ b/src/connection/reliable.rs
@@ -1,6 +1,6 @@
 use crate::connection::ack_system::AckSystem;
 use crate::connection::ordering_system::OrderingSystem;
-use crate::messages::AckMsg;
+use crate::messages::{AckMsg, NetMsg};
 use crate::net::MsgHeader;
 use crate::{Guarantees, MType, MsgTable};
 use std::time::{Duration, Instant};
@@ -20,16 +20,16 @@ const ACK_MSG_LIMIT: Option<Duration> = Some(Duration::from_millis(100));
 ///
 /// Since these differ between client and server (server needs to keep track of a from address),
 /// these need to be generic parameters.
-pub(crate) struct ReliableSystem<SD: Clone, RD> {
-    msg_table: MsgTable,
+pub(crate) struct ReliableSystem<SD: Clone, RD, C: NetMsg, A: NetMsg, R: NetMsg, D: NetMsg> {
+    msg_table: MsgTable<C, A, R, D>,
     last_ack_msg: Instant,
     ack_sys: AckSystem<SD>,
     ordering_sys: OrderingSystem<RD>,
 }
 
-impl<SD: Clone, RD> ReliableSystem<SD, RD> {
+impl<SD: Clone, RD, C: NetMsg, A: NetMsg, R: NetMsg, D: NetMsg> ReliableSystem<SD, RD, C, A, R, D> {
     /// Creates a new [`ReliableSystem`].
-    pub fn new(msg_table: MsgTable) -> Self {
+    pub fn new(msg_table: MsgTable<C, A, R, D>) -> Self {
         let m_table_count = msg_table.mtype_count();
         ReliableSystem {
             msg_table,

--- a/src/connection/reliable.rs
+++ b/src/connection/reliable.rs
@@ -3,7 +3,6 @@ use crate::connection::ordering_system::OrderingSystem;
 use crate::messages::AckMsg;
 use crate::net::MsgHeader;
 use crate::{Guarantees, MType, MsgTable};
-use std::fmt::Debug;
 use std::time::{Duration, Instant};
 
 /// A minimum time for ack messages to be sent.
@@ -21,14 +20,14 @@ const ACK_MSG_LIMIT: Option<Duration> = Some(Duration::from_millis(100));
 ///
 /// Since these differ between client and server (server needs to keep track of a from address),
 /// these need to be generic parameters.
-pub(crate) struct ReliableSystem<SD: Debug + Clone, RD: Debug> {
+pub(crate) struct ReliableSystem<SD: Clone, RD> {
     msg_table: MsgTable,
     last_ack_msg: Instant,
     ack_sys: AckSystem<SD>,
     ordering_sys: OrderingSystem<RD>,
 }
 
-impl<SD: Debug + Clone, RD: Debug> ReliableSystem<SD, RD> {
+impl<SD: Clone, RD> ReliableSystem<SD, RD> {
     /// Creates a new [`ReliableSystem`].
     pub fn new(msg_table: MsgTable) -> Self {
         let m_table_count = msg_table.mtype_count();

--- a/src/connection/test_connection.rs
+++ b/src/connection/test_connection.rs
@@ -20,9 +20,9 @@ fn test_reliability() {
     let server_addr = "127.0.0.1:7777".parse().unwrap();
     let client_addr = "127.0.0.1:0".parse().unwrap();
 
-    let mut server_connection: ServerConnection<UdpServerTransport> =
+    let mut server_connection: ServerConnection<UdpServerTransport, Connection, Accepted, Rejected, Disconnect> =
         ServerConnection::new(msg_table.clone(), server_addr).unwrap();
-    let mut client_connection: ClientConnection<UdpClientTransport> =
+    let mut client_connection: ClientConnection<UdpClientTransport, Connection, Accepted, Rejected, Disconnect> =
         ClientConnection::new(msg_table);
 
     client_connection.connect(client_addr, server_addr).expect("Connection failed");
@@ -158,7 +158,7 @@ pub struct Accepted;
 pub struct Rejected;
 
 /// Builds a table with all these test messages and returns it's parts.
-pub fn get_msg_table() -> MsgTable {
+pub fn get_msg_table() -> MsgTable<Connection, Accepted, Rejected, Disconnect> {
     let mut builder = MsgTableBuilder::new();
     builder
         .register_ordered::<ReliableMsg>(Guarantees::ReliableOrdered)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,7 @@ mod server;
 mod transport;
 mod util;
 
-pub use client::{Client, OptionPendingClient, PendingClient};
+pub use client::Client;
 pub use messages::Response;
 pub use message_table::{Guarantees, MsgRegError, MsgTable, MsgTableBuilder};
 pub use net::{CId, MType};

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -9,7 +9,7 @@ use std::io::ErrorKind;
 use downcast_rs::{Downcast, impl_downcast};
 
 pub trait NetMsg: Downcast + Send + Sync + Debug {}
-impl<T: 'static + Send + Sync + Debug> NetMsg for T {}
+impl<T: Downcast + Send + Sync + Debug> NetMsg for T {}
 impl_downcast!(NetMsg);
 
 /// An enum representing the possible responses to a connection request.

--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,11 +1,16 @@
 //! A module for internal messages that are used by carrier pigeon.
 //! This includes [`AckMsg`] and [`PingMsg`].
 
-use std::any::Any;
+use std::fmt::Debug;
 use crate::net::AckNum;
 use serde::{Deserialize, Serialize};
 use std::io;
 use std::io::ErrorKind;
+use downcast_rs::{Downcast, impl_downcast};
+
+pub trait NetMsg: Downcast + Send + Sync + Debug {}
+impl<T: 'static + Send + Sync + Debug> NetMsg for T {}
+impl_downcast!(NetMsg);
 
 /// An enum representing the possible responses to a connection request.
 ///
@@ -13,7 +18,7 @@ use std::io::ErrorKind;
 /// upon being accepted or rejected respectively.
 /// This could be server info or a reason for rejecting.
 #[derive(Serialize, Deserialize, Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub enum Response<A: Any + Send + Sync, R: Any + Send + Sync> {
+pub enum Response<A: NetMsg, R: NetMsg> {
     /// The connection request is accepted.
     Accepted(A),
     /// The connection request is rejected.

--- a/src/server.rs
+++ b/src/server.rs
@@ -86,26 +86,10 @@ impl<C: NetMsg, A: NetMsg, R: NetMsg, D: NetMsg> Server<C, A, R, D> {
     /// the respective message.
     ///
     /// Returns the number of handled connections.
-    ///
-    /// ### Panics
-    /// Panics if the generic parameters `C`, `A` and `R` are not the same `C`, `A` and `R`
-    /// that you passed into [`MsgTableBuilder::build`](crate::MsgTableBuilder::build).
     pub fn handle_new_cons(
         &mut self,
         hook: impl FnMut(CId, SocketAddr, C) -> Response<A, R>,
     ) -> u32 {
-        // verify that `C` and `R` are the right type.
-        let c_tid = TypeId::of::<C>();
-        let r_tid = TypeId::of::<Response<A, R>>();
-        if self.msg_table.tid_map.get(&c_tid) != Some(&CONNECTION_M_TYPE)
-            || self.msg_table.tid_map.get(&r_tid) != Some(&RESPONSE_M_TYPE)
-        {
-            panic!(
-                "generic parameters `C`, `A`, and `R` need to match the generic parameters \
-            that you passed into `MsgTableBuilder::build()`"
-            );
-        }
-
         self.connection.handle_pending(hook)
     }
 

--- a/tests/helper/mod.rs
+++ b/tests/helper/mod.rs
@@ -3,12 +3,15 @@
 
 use crate::helper::test_messages::{get_msg_table, Connection, Disconnect, Accepted, Rejected};
 use carrier_pigeon::net::{ClientConfig, ServerConfig};
-use carrier_pigeon::{Client, Response, Server};
 use log::{debug, info};
 use std::thread::sleep;
 use std::time::Duration;
+use carrier_pigeon::Response;
 
 pub mod test_messages;
+
+type Client = carrier_pigeon::Client<Connection, Accepted, Rejected, Disconnect>;
+type Server = carrier_pigeon::Server<Connection, Accepted, Rejected, Disconnect>;
 
 pub const SERVER_ADDR_LOCAL: &str = "127.0.0.1:7778";
 pub const CLIENT_ADDR_LOCAL: &str = "127.0.0.1:7776";

--- a/tests/helper/test_messages.rs
+++ b/tests/helper/test_messages.rs
@@ -62,7 +62,7 @@ pub struct Rejected {
 
 
 /// Builds a table with all these test messages and returns it's parts.
-pub fn get_msg_table() -> MsgTable {
+pub fn get_msg_table() -> MsgTable<Connection, Accepted, Rejected, Disconnect> {
     let mut builder = MsgTableBuilder::new();
     builder
         .register_ordered::<ReliableMsg>(Guarantees::Reliable)


### PR DESCRIPTION
This adds the `NetMsg` trait, and generics back into `carrier-pigeon`. The generics help remove some type checking code and allows those checks to be done a compile time. The biggest drawback of this is that it adds a lot of type complexity. This can be mitigated using type aliases. This also unblocks a feature I am working on.